### PR TITLE
Fix all open security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "generate-readme": "node scripts/generate-readme-assets.js"
   },
   "resolutions": {
-    "typescript": "~5.8.0"
+    "typescript": "~5.8.0",
+    "brace-expansion": ">=2.0.3"
   },
   "devDependencies": {
     "typescript": "~5.8.0",

--- a/packages/caml-react/src/CamlHero.tsx
+++ b/packages/caml-react/src/CamlHero.tsx
@@ -19,7 +19,7 @@ export interface CamlHeroRendererProps {
  * Render a title line, wrapping {text} in accent spans.
  */
 function renderTitleLine(line: string, index: number): React.ReactNode {
-  const parts = line.split(/(\{[^}]+\})/);
+  const parts = line.split(/(\{[^{}]+\})/);
   return (
     <React.Fragment key={index}>
       {index > 0 && <br />}

--- a/packages/caml/src/blockParsers.ts
+++ b/packages/caml/src/blockParsers.ts
@@ -45,14 +45,13 @@ function parseCardItem(raw: string): CamlCardItem {
   const headerLine = lines[0].trim();
 
   // Parse header: **Label** | meta | #color
-  const headerMatch = headerLine.match(
-    /^\*\*(.+?)\*\*(?:\s*\|\s*(.+?))?(?:\s*\|\s*(#[0-9a-fA-F]{6}))?$/
-  );
+  const parts = headerLine.split("|").map((s) => s.trim());
+  const boldMatch = parts[0].match(/^\*\*([^*]+)\*\*$/);
 
   const item: CamlCardItem = {
-    label: headerMatch ? headerMatch[1].trim() : headerLine,
-    meta: headerMatch?.[2]?.trim(),
-    accent: headerMatch?.[3]?.trim(),
+    label: boldMatch ? boldMatch[1].trim() : parts[0],
+    meta: parts[1] || undefined,
+    accent: parts[2]?.match(/^#[0-9a-fA-F]{6}$/) ? parts[2] : undefined,
   };
 
   // Parse body and footer from remaining lines
@@ -87,25 +86,25 @@ function parsePillItem(raw: string): CamlPillItem {
   const headerLine = lines[0].trim();
 
   // Parse header: BIG_TEXT | **Label** | detail
-  const headerMatch = headerLine.match(
-    /^(.+?)\s*\|\s*\*\*(.+?)\*\*(?:\s*\|\s*(.+))?$/
-  );
+  const parts = headerLine.split("|").map((s) => s.trim());
+  const boldMatch = parts[1]?.match(/^\*\*([^*]+)\*\*$/);
 
   const item: CamlPillItem = {
-    bigText: headerMatch ? headerMatch[1].trim() : headerLine,
-    label: headerMatch ? headerMatch[2].trim() : "",
-    detail: headerMatch?.[3]?.trim(),
+    bigText: parts[0] || headerLine,
+    label: boldMatch ? boldMatch[1].trim() : (parts[1] || ""),
+    detail: parts[2] || undefined,
   };
 
   // Parse status line
   for (let i = 1; i < lines.length; i++) {
     const trimmed = lines[i].trim();
-    const statusMatch = trimmed.match(
-      /^status:\s*(.+?)(?:\s*\|\s*(#[0-9a-fA-F]{6}))?$/
-    );
-    if (statusMatch) {
-      item.status = statusMatch[1].trim();
-      item.statusColor = statusMatch[2]?.trim();
+    if (trimmed.startsWith("status:")) {
+      const statusParts = trimmed.slice(7).split("|").map((s) => s.trim());
+      item.status = statusParts[0];
+      const colorPart = statusParts[1];
+      if (colorPart?.match(/^#[0-9a-fA-F]{6}$/)) {
+        item.statusColor = colorPart;
+      }
     }
   }
 
@@ -197,14 +196,16 @@ function parseTabContent(attrsStr: string, body: string): CamlTab {
     }
 
     // Section heading: #### Heading {highlight}
-    const headingMatch = trimmed.match(
-      /^####\s+(.+?)(?:\s*\{highlight\})?\s*$/
-    );
-    if (headingMatch) {
+    if (trimmed.startsWith("#### ")) {
       flushSection();
+      let headingText = trimmed.slice(4).trim();
+      const isHighlight = headingText.endsWith("{highlight}");
+      if (isHighlight) {
+        headingText = headingText.slice(0, -"{highlight}".length).trim();
+      }
       currentSection = {
-        heading: headingMatch[1].trim(),
-        highlight: trimmed.includes("{highlight}"),
+        heading: headingText,
+        highlight: isHighlight,
         content: "",
       };
       continue;
@@ -256,14 +257,9 @@ function parseTimeline(
 
     if (inLegend) {
       if (trimmed.startsWith("- ")) {
-        const legendMatch = trimmed
-          .slice(2)
-          .match(/^(.+?)\s*\|\s*(#[0-9a-fA-F]{6})\s*$/);
-        if (legendMatch) {
-          legend.push({
-            label: legendMatch[1].trim(),
-            color: legendMatch[2],
-          });
+        const parts = trimmed.slice(2).split("|").map((s) => s.trim());
+        if (parts[1]?.match(/^#[0-9a-fA-F]{6}$/)) {
+          legend.push({ label: parts[0], color: parts[1] });
         }
       } else if (trimmed === "" || trimmed.startsWith("-")) {
         inLegend = false;
@@ -273,14 +269,12 @@ function parseTimeline(
     }
 
     if (!inLegend && trimmed.startsWith("- ")) {
-      const itemMatch = trimmed
-        .slice(2)
-        .match(/^(.+?)\s*\|\s*(.+?)\s*\|\s*(.+)$/);
-      if (itemMatch) {
+      const parts = trimmed.slice(2).split("|").map((s) => s.trim());
+      if (parts.length >= 3) {
         items.push({
-          date: itemMatch[1].trim(),
-          label: itemMatch[2].trim(),
-          side: itemMatch[3].trim().toLowerCase(),
+          date: parts[0],
+          label: parts[1],
+          side: parts[2].toLowerCase(),
         });
       }
     }
@@ -302,7 +296,7 @@ function parseCta(_attrs: Record<string, string>, body: string): CamlCta {
     if (!trimmed.startsWith("- ")) continue;
 
     // Parse: - [Label](href) {primary}
-    const match = trimmed.match(/^-\s*\[(.+?)\]\((.+?)\)(?:\s*\{primary\})?$/);
+    const match = trimmed.match(/^-\s*\[([^\]]+)\]\(([^)]+)\)(?:\s*\{primary\})?$/);
     if (match) {
       items.push({
         label: match[1],
@@ -326,7 +320,7 @@ function parseSignup(_attrs: Record<string, string>, body: string): CamlSignup {
 
   for (const line of lines) {
     const trimmed = line.trim();
-    const kvMatch = trimmed.match(/^(title|button):\s*(.+)$/);
+    const kvMatch = trimmed.match(/^(title|button):[ \t]*(\S.*)$/);
     if (kvMatch) {
       if (kvMatch[1] === "title") result.title = kvMatch[2].trim();
       if (kvMatch[1] === "button") result.button = kvMatch[2].trim();
@@ -353,9 +347,9 @@ function parseCorpusStats(
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed.startsWith("- ")) continue;
-    const match = trimmed.slice(2).match(/^(.+?)\s*\|\s*(.+)$/);
-    if (match) {
-      items.push({ key: match[1].trim(), label: match[2].trim() });
+    const parts = trimmed.slice(2).split("|").map((s) => s.trim());
+    if (parts.length >= 2) {
+      items.push({ key: parts[0], label: parts[1] });
     }
   }
 
@@ -401,14 +395,9 @@ function parseMap(attrs: Record<string, string>, body: string): CamlMap {
 
     if (inLegend) {
       if (trimmed.startsWith("- ")) {
-        const legendMatch = trimmed
-          .slice(2)
-          .match(/^(.+?)\s*\|\s*(#[0-9a-fA-F]{6})\s*$/);
-        if (legendMatch) {
-          legend.push({
-            label: legendMatch[1].trim(),
-            color: legendMatch[2],
-          });
+        const parts = trimmed.slice(2).split("|").map((s) => s.trim());
+        if (parts[1]?.match(/^#[0-9a-fA-F]{6}$/)) {
+          legend.push({ label: parts[0], color: parts[1] });
         } else {
           inLegend = false;
         }
@@ -488,7 +477,7 @@ function parseCaseHistory(
     const trimmed = line.trim();
 
     // Key-value header
-    const kvMatch = trimmed.match(/^(title|docket|status):\s*(.+)$/);
+    const kvMatch = trimmed.match(/^(title|docket|status):[ \t]*(\S.*)$/);
     if (kvMatch) {
       const key = kvMatch[1] as "title" | "docket" | "status";
       result[key] = kvMatch[2].trim();

--- a/packages/caml/src/tokenizer.ts
+++ b/packages/caml/src/tokenizer.ts
@@ -402,7 +402,7 @@ export function parseCaml(source: string): CamlDocument {
   let frontmatter: CamlFrontmatter = {};
   let body = source;
 
-  const fmMatch = source.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  const fmMatch = source.match(/^---[ \t]*\n([\s\S]*?)\n---[ \t]*\n([\s\S]*)$/);
   if (fmMatch) {
     frontmatter = parseYamlFrontmatter(fmMatch[1]);
     body = fmMatch[2];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1733,13 +1733,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"balanced-match@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "balanced-match@npm:1.0.2"
-  checksum: 10c0/9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
-  languageName: node
-  linkType: hard
-
 "balanced-match@npm:^4.0.2":
   version: 4.0.4
   resolution: "balanced-match@npm:4.0.4"
@@ -1765,16 +1758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.2":
+"brace-expansion@npm:>=2.0.3":
   version: 5.0.5
   resolution: "brace-expansion@npm:5.0.5"
   dependencies:


### PR DESCRIPTION
## Summary

- **13 ReDoS vulnerabilities (high)**: Replaced backtracking-prone regexes in `blockParsers.ts`, `tokenizer.ts`, and `CamlHero.tsx` with pipe-splitting (`str.split("|")`) or constrained character classes (`[^|]`, `[^*]`, `[^\]]`, `[^{}]`, `[ \t]*`)
- **CI permissions (medium)**: Added `permissions: contents: read` to `ci.yml` workflow
- **brace-expansion DoS (medium)**: Added `>=2.0.3` resolution in `package.json` to fix CVE in transitive dependency

## Test plan
- [x] All 44 existing unit tests pass
- [x] Build succeeds for all packages
- [ ] CI pipeline passes on this PR
- [ ] CodeQL re-scan confirms alerts resolved