### PR TITLE
Fix invisible Pullquote text on dark theme

### DIFF
--- a/packages/caml-react/ct-tests/CamlBlocks.ct.tsx
+++ b/packages/caml-react/ct-tests/CamlBlocks.ct.tsx
@@ -49,6 +49,28 @@ test("prose renders pullquote", async ({ mount }) => {
   await expect(blockquote).toBeVisible();
 });
 
+test("prose pullquote uses light text on dark background", async ({ mount }) => {
+  const block: CamlProse = {
+    type: "prose",
+    content: '>>> "Visible on dark"',
+  };
+
+  const component = await mount(
+    <CamlTestWrapper>
+      <CamlBlockRenderer block={block} dark />
+    </CamlTestWrapper>
+  );
+
+  // On dark, the pullquote text must not collapse to the near-black heading
+  // color (#0f172a) — see issue #9.
+  const blockquote = component.locator("blockquote");
+  await expect(blockquote).toBeVisible();
+  const color = await blockquote.evaluate(
+    (el) => getComputedStyle(el).color
+  );
+  expect(color).not.toBe("rgb(15, 23, 42)");
+});
+
 test("cards renders grid with items", async ({ mount }) => {
   const block: CamlCards = {
     type: "cards",

--- a/packages/caml-react/src/CamlBlocks.tsx
+++ b/packages/caml-react/src/CamlBlocks.tsx
@@ -211,7 +211,7 @@ function ProseBlock({
     <ProseContainer $dark={dark}>
       {segments.map((seg, i) => {
         if (seg.type === "pullquote") {
-          return <Pullquote key={i}>{seg.text}</Pullquote>;
+          return <Pullquote key={i} $dark={dark}>{seg.text}</Pullquote>;
         }
         return <React.Fragment key={i}>{renderMd(seg.text)}</React.Fragment>;
       })}

--- a/packages/caml-react/src/styles.ts
+++ b/packages/caml-react/src/styles.ts
@@ -194,7 +194,7 @@ export const ProseContainer = styled.div<{ $dark?: boolean }>`
   }
 `;
 
-export const Pullquote = styled.blockquote`
+export const Pullquote = styled.blockquote<{ $dark?: boolean }>`
   border-left: 6px solid ${({ theme }) => theme.caml.colors.accent};
   padding: 1.5rem 2rem;
   margin: 2rem 0;
@@ -202,7 +202,8 @@ export const Pullquote = styled.blockquote`
   font-size: 1.25rem;
   font-style: italic;
   line-height: 1.7;
-  color: ${({ theme }) => theme.caml.colors.heading};
+  color: ${({ $dark, theme }) =>
+    $dark ? theme.caml.colors.surfaceLight : theme.caml.colors.heading};
   background: ${({ theme }) => theme.caml.accentAlpha(0.05)};
   border-radius: 0 8px 8px 0;
 `;


### PR DESCRIPTION
Closes #9.

## Problem

`Pullquote` hardcoded `theme.caml.colors.heading` (a near-black navy intended for light surfaces). On dark-themed CAML articles the pullquote text rendered as dark navy on dark navy and was effectively invisible — even though the prose paragraph immediately above it was fine, because `ProseContainer` already has a `$dark` branch.

## Fix

Surgical, mirrors the pattern that `ChapterTitle` and `ProseContainer` already use:

1. `packages/caml-react/src/styles.ts` — `Pullquote` gains a `$dark?: boolean` prop and switches `color` between `theme.caml.colors.heading` (light surface) and `theme.caml.colors.surfaceLight` (dark surface), the same swap `ChapterTitle` does.
2. `packages/caml-react/src/CamlBlocks.tsx` — `ProseBlock` forwards its existing `dark` prop to the `<Pullquote>` it renders, so the pullquote tracks whatever signal `ProseContainer` already responds to. No new prop on `CamlBlockRenderer`.
3. `packages/caml-react/ct-tests/CamlBlocks.ct.tsx` — regression test asserting the dark-mode pullquote does not collapse to the near-black heading color.

## Audit notes (issue point 3)

I checked the rest of `ProseContainer` — `p`, `strong`, and `code` all already have `$dark` branches. Links use the accent color which works on either surface. `CamlMarkdown` adds no styled colors of its own and inherits from `ProseContainer`. The pullquote was the only primitive missing the dark branch.

## Verification

- `yarn lint` (tsc --noEmit) clean
- `yarn build` succeeds
- `yarn test` — 103/103 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_011izSzhWbVAK4GG6EGjCyZD)_